### PR TITLE
SAYT 500 Errors With Third Party JS

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,2 +1,4 @@
+- <a href="https://github.com/groupby/issues/issues/713">iss1</a> SAYT 500 Errors With Third Party JS
+
 Changelog
 ---


### PR DESCRIPTION
Created by: gpejski <img height="16px" src="https://avatars.githubusercontent.com/u/7842633?v=3">
Parent groupby/issues#713

Austin Kayak just sent me this email about about 500 errors they are getting with the latest version of sayt.js (from the SAYT Tutorial). Looks like our sayt,js is interacting with some third party js they are using. Obviously we can't really help them debug code we don't have and it may not be our issue to deal with?

So I'm not sure what my response should be. Do I politely say that we can't be responsible for code that someone else has written interacting with our system? And perhaps also sayt that our sayt.js is a reference implementation and if it doesn't fit their needs, that they are welcome to modify it to their requirements? Or is it possible that our sayt.js has an area that we could tighten up so that they don't get 500 errors? Do we throw them a bone and offer to take a look to see if we can figure it out?

Finally, is it worth integrating their security error issue on line 200 that they mention?

Here's their email

> We are having a problem with the SAYT js provided by GroupBy. We have two third party javascript includes that render iframes on our pages. When we use the down arrow to navigate the SAYT results we get this error:
> 
> Uncaught SecurityError: Blocked a frame with origin "<Our URL>" from accessing a frame with origin "<Third Party URL>". Protocols, domains, and ports must match.
> 
> which seems to be linked to line 200 of SAYT.js:
> (enable ? lf.addClass : lf.removeClass)('ui-state-focus');
> 
> If we comment out the first third party js block that generates an iframe. It hits the second iframe. If we comment out the second block so that iFrame is not generated we get a 500 error that looks like this: https://austinkayak.groupbycloud.com/api/v1/sayt/search?callback=jQuery1710…=Production&productItems=4&searchItems=0&navigationItems=0&_=1428433606896
> 
> I'm not sure why this line causes our third party iframes to try to reload their content, but we, obviously, have this issue with the SAYT js we currently have implemented on our live site.
> 
> **Update**: As I was typing this Walter was able to fix the "SecurityError" issue by changing line 200 to:
> lf[enable ? 'addClass' : 'removeClass']('ui-state-focus');
> 
> Now if you could provide some insight as to why the 500 errors are occurring that would be great.
- [ ] groupby/documentation#83
- [ ] groupby/bindle#1437
